### PR TITLE
Add the ability to return relative luminance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ WCAGColorContrast.ratio('999', 'ffffff')
 #=> 2.849027755287037
 ```
 
+Can also calculate the relative luminance of a color
+
+```ruby
+WCAGColorContrast.relative_luminance('008800')
+#=> 0.17608318886144392
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/wcag_color_contrast.rb
+++ b/lib/wcag_color_contrast.rb
@@ -8,6 +8,10 @@ module WCAGColorContrast
     Ratio.new.ratio(*args)
   end
 
+  def self.relative_luminance(rgb)
+    Ratio.new.relative_luminance(rgb)
+  end
+
   class Ratio
     # Calculate contast ratio beetween RGB1 and RGB2.
     def ratio(rgb1, rgb2)
@@ -21,6 +25,14 @@ module WCAGColorContrast
       l2 = srgb_lightness(srgb2)
 
       l1 > l2 ? (l1 + 0.05) / (l2 + 0.05) : (l2 + 0.05) / (l1 + 0.05)
+    end
+
+    # Calculate the relative luminance for an rgb color
+    def relative_luminance(rgb)
+      raise InvalidColorError, rgb unless valid_rgb?(rgb)
+
+      srgb = rgb_to_srgba(rgb)
+      srgb_lightness(srgb)
     end
 
     private

--- a/test/test.rb
+++ b/test/test.rb
@@ -8,4 +8,9 @@ class WCAGColorContrastTest < MiniTest::Unit::TestCase
     assert_in_delta 1.425, WCAGColorContrast.ratio('d8d8d8', 'fff')
     assert_in_delta 1.956, WCAGColorContrast.ratio('eee', 'AAABBB')
   end
+
+  def test_relative_luminance
+    assert_equal 1, WCAGColorContrast.relative_luminance('ffffff')
+    assert_in_delta 0.176, WCAGColorContrast.relative_luminance('008800')
+  end
 end


### PR DESCRIPTION
I need this feature currently for a project I'm working on, [pygments-high-contrast-stylesheets](https://github.com/mpchadwick/pygments-high-contrast-stylesheets).

[This script](https://github.com/mpchadwick/pygments-high-contrast-stylesheets/blob/f7c0f5077f8ada40f7a997fc1668c322358b6828/tools/test-stylesheet) parses the stylesheet and identifies style rules with insufficient color contrast for the text against the background color. It also [attempts to provide a recommendation for changing the text color](https://github.com/mpchadwick/pygments-high-contrast-stylesheets/blob/f7c0f5077f8ada40f7a997fc1668c322358b6828/tools/test-stylesheet#L32). Whether or not to call `lighten` or `darken` depends on the relative luminance of the background and text color. This change would allow me to access that info from this library, which I've been using. 

It could come in handy for others as well.