### PR TITLE
Fix bug in 3 digit to 6 digit RGB conversion

### DIFF
--- a/lib/wcag_color_contrast.rb
+++ b/lib/wcag_color_contrast.rb
@@ -39,7 +39,7 @@ module WCAGColorContrast
 
     # Convert RGB color to sRGB.
     def rgb_to_srgba(rgb)
-      rgb << rgb if rgb.size == 3
+      rgb = ([rgb.split('')] * 2).transpose.join if rgb.size == 3
       [
         rgb.slice(0,2).to_i(16) / 255.0,
         rgb.slice(2,2).to_i(16) / 255.0,

--- a/test/test.rb
+++ b/test/test.rb
@@ -7,6 +7,7 @@ class WCAGColorContrastTest < MiniTest::Unit::TestCase
     assert_in_delta 2.849, WCAGColorContrast.ratio('999', 'ffffff')
     assert_in_delta 1.425, WCAGColorContrast.ratio('d8d8d8', 'fff')
     assert_in_delta 1.956, WCAGColorContrast.ratio('eee', 'AAABBB')
+    assert_in_delta 16.148, WCAGColorContrast.ratio('123', 'fff')
   end
 
   def test_relative_luminance


### PR DESCRIPTION
'123' should become '112233' and not '123123'

Note the same issue exists in the JS project you based this on. I'll create a PR against that project too :)